### PR TITLE
handle value type case in GetSortExpression

### DIFF
--- a/DataTables.Queryable.Support/DataTables.Queryable.Support.csproj
+++ b/DataTables.Queryable.Support/DataTables.Queryable.Support.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,7 +7,7 @@
     <AssemblyOriginatorKeyFile>datatables.support.pfx</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.8.2</Version>
-    <Authors>B. Nielander</Authors>
+    <Authors>B. Nielander, Fixes: INGCRM Dev Team</Authors>
     <Company />
     <PackageTags>DataTables AutoMapper LINQ Expressions jQuery</PackageTags>
     <PackageId>DataTables.Queryable.Support</PackageId>

--- a/DataTables.Queryable.Support/Queryables/Expressions/Creators/QueryablesExpressionCreator.cs
+++ b/DataTables.Queryable.Support/Queryables/Expressions/Creators/QueryablesExpressionCreator.cs
@@ -143,6 +143,10 @@ namespace DataTables.Queryable.Support.Queryables.Expressions.Creators
                 yield return Expression.Lambda<Func<TModel, object>>(hasValueExpression, new ParameterExpression[] { parameterExpression });
                 yield return Expression.Lambda<Func<TModel, object>>(valueExpression, new ParameterExpression[] { parameterExpression });
             }
+            else if (sourcePropertyType.IsValueType)
+            {
+                yield return Expression.Lambda<Func<TModel, object>>(Expression.Convert(expression, typeof(object)), new ParameterExpression[] { parameterExpression });
+            }
             else
             {
                 yield return Expression.Lambda<Func<TModel, object>>(expression, new ParameterExpression[] { parameterExpression });


### PR DESCRIPTION
Hello, I am an employee of ING Bank Śląski S.A. and we have decided to contribute our changes back upstream. The changes concern the GetSortExpression method, which previously did not handle the case where the source property's type was a value type.